### PR TITLE
Fix patient booking endpoint

### DIFF
--- a/back-end/SkinCancer.Api/Controllers/ClinicController.cs
+++ b/back-end/SkinCancer.Api/Controllers/ClinicController.cs
@@ -55,6 +55,8 @@ namespace SkinCancer.Api.Controllers
 
             return Ok(clinicDto);
         }
+
+
         [HttpGet("GetClinicById{id:int}")]
         public async Task<ActionResult<DoctorClinicDetailsDto>> GetClinicByIdAsync(int id)
         {

--- a/back-end/SkinCancer.Entities/Models/Clinic.cs
+++ b/back-end/SkinCancer.Entities/Models/Clinic.cs
@@ -27,6 +27,8 @@ namespace SkinCancer.Entities.Models
         [MaxLength(500)]
         public string Description { get; set; }
 
+/*        public decimal? TotalAmountReceived { get; set; }   
+*/
         [Required, MaxLength(100)]
         public string DoctorName { get; set; }
 

--- a/back-end/SkinCancer.Entities/ModelsDtos/ScheduleDtos/BookScheduleDto.cs
+++ b/back-end/SkinCancer.Entities/ModelsDtos/ScheduleDtos/BookScheduleDto.cs
@@ -11,6 +11,6 @@ namespace SkinCancer.Entities.ModelsDtos.ScheduleDtos
         public int ScheduleId { get; set; }
 
         public string PatientId { get; set; }
-
+        
     }
 }

--- a/back-end/SkinCancer.Repositories/Interface/IScheduleRepository.cs
+++ b/back-end/SkinCancer.Repositories/Interface/IScheduleRepository.cs
@@ -15,5 +15,8 @@ namespace SkinCancer.Repositories.Interface
 
         bool IsPatientInClinic(PatientRateDto dto);
 
+        Task<int?> GetClinicId(int scheduleId);
+
+
     }
 }

--- a/back-end/SkinCancer.Repositories/Repository/ScheduleRepository.cs
+++ b/back-end/SkinCancer.Repositories/Repository/ScheduleRepository.cs
@@ -21,6 +21,17 @@ namespace SkinCancer.Repositories.Repository
             _context = context;
         }
 
+        public async Task<int?> GetClinicId(int scheduleId)
+        {
+            var schedule = await _context.Schedules.
+               FirstOrDefaultAsync(x => x.Id == scheduleId);
+            if (schedule == null)
+            {
+                return null;
+            }
+            return schedule.ClinicId;
+        }
+
         public async Task<IEnumerable<Schedule>> GetClinicSchedulesById(int clinicId)
         => await _context.Schedules.Where(s=>s.ClinicId == clinicId).ToListAsync();
 

--- a/back-end/SkinCancer.Services/ScheduleServices/ScheduleService.cs
+++ b/back-end/SkinCancer.Services/ScheduleServices/ScheduleService.cs
@@ -140,6 +140,39 @@ namespace SkinCancer.Services.ScheduleServices
                         IsSucceeded = false
                     };
                 }
+                   
+               
+                var result = await _unitOfWork.scheduleRepository.GetClinicId(dto.ScheduleId);
+
+                if (result == null)
+                {
+                    return new ProcessResult
+                    {
+                        Message = "No Schedule assigned with this id"
+                    };
+                }
+
+                 
+                var checkPatientInClinic =  _unitOfWork.scheduleRepository
+                    .IsPatientInClinic(new Entities.ModelsDtos.PatientDtos.PatientRateDto
+                    {
+                        ClinicId = result.Value,
+                        PatientId = dto.PatientId,
+                    });
+
+                if (checkPatientInClinic)
+                    return new ProcessResult
+                    {
+                        Message = "Patient has booked in the same clinic before"
+                    };
+
+                if (schedule.IsBooked)
+                    return new ProcessResult
+                    {
+                        Message = "this schedule has a patient already"
+                    };
+
+
                 schedule.PatientId = dto.PatientId;
                 schedule.IsBooked = true;
 


### PR DESCRIPTION
Ensure a patient cannot book more than once in the same clinic, while allowing bookings in multiple different clinics. This update improves the booking logic to prevent duplicate appointments in the same clinic.